### PR TITLE
Add missing region image URLs from regions JSON map

### DIFF
--- a/tools/spiders/configs.json
+++ b/tools/spiders/configs.json
@@ -26,6 +26,7 @@
       "/static/img/maps/Auslan/NorthernDialect-traditional.png": ["northern", "qld", "nsw", "act"],
       "/static/img/maps/Auslan/WesternAustralia-traditional.png": ["wa"],
       "/static/img/maps/Auslan/NorthernTerritory-traditional.png": ["nt"],
+      "/static/img/maps/Auslan/SouthAustralia.png": ["sa"],
       "/static/img/maps/Auslan/SouthAustralia-traditional.png": ["sa"],
       "/static/img/maps/Auslan/Queensland-traditional.png": ["qld"],
       "/static/img/maps/Auslan/NewSouthWales-traditional.png": ["nsw", "act"],

--- a/tools/spiders/configs.json
+++ b/tools/spiders/configs.json
@@ -20,6 +20,7 @@
     
     "//6": "maps state image urls to tag sets, to translate that (very inaccessible) presentation in to meaningful machine data",
     "regions": {
+      "/static/img/maps/Auslan/AustraliaWide.png": ["everywhere", "southern", "northern", "wa", "nt", "sa", "qld", "nsw", "act", "vic", "tas"],
       "/static/img/maps/Auslan/AustraliaWide-traditional.png": ["everywhere", "southern", "northern", "wa", "nt", "sa", "qld", "nsw", "act", "vic", "tas"],
       "/static/img/maps/Auslan/SouthernDialect-traditional.png": ["southern", "wa", "nt", "sa", "vic", "tas"],
       "/static/img/maps/Auslan/NorthernDialect-traditional.png": ["northern", "qld", "nsw", "act"],


### PR DESCRIPTION
In my scraping for https://github.com/banool/auslan_dictionary/ I came across this URL. The image appears to be identical to the one with the `-traditional` suffix.